### PR TITLE
Update models.cfg

### DIFF
--- a/models.cfg
+++ b/models.cfg
@@ -1,3 +1,3 @@
-mmodel "dc/data_cube_1x"
-mmodel "dc/data_cube_4x"
+mmodel "dc/cube_1x"
+mmodel "dc/cube_4x"
 mmodel "dc/virtual-platform-ripple"


### PR DESCRIPTION
fix path for model "dc/cube_1x" and mmodel "dc/cube_4x"

Fixes #

Changes proposed in this request:
Path fixed in cfg.

@qreeves can you also remove 
data_cube_1x and data_cube_4x ?
They are old and already replaced by cube_1x and cube_4x in this pr.